### PR TITLE
h2の接続情報を変更

### DIFF
--- a/src/main/resources/db/h2-datasource.xml
+++ b/src/main/resources/db/h2-datasource.xml
@@ -11,8 +11,6 @@
     </component>
     <component name="dialect" class="nablarch.core.db.dialect.H2Dialect" />
 
-    <!-- ResultSetConvertorが欲しくなったら、ここに追加する。 -->
-
     <!-- データベース接続失敗判定 -->
     <component name="dbAccessExceptionFactory" class="nablarch.core.db.connection.exception.BasicDbAccessExceptionFactory">
     </component>

--- a/src/main/resources/db/h2-db.config
+++ b/src/main/resources/db/h2-db.config
@@ -1,3 +1,3 @@
-db.url = jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+db.url = jdbc:h2:~/ssd.db;LOCK_TIMEOUT=15000
 db.user = sa
 db.password = pass


### PR DESCRIPTION
h2の接続情報を変更

* in-memoryからfileに変更
  (他のDBと同じ仕組みでテストを実行するため、事前に環境構築済みのデータベースが必要なため)
* ロックタイムアウト時間をデフォルトから変更
  ロックタイムアウトで、一部ロック待機を伴うテストが実施できなかったため

#4