### PR TITLE
feat: システムプロパティをクリーンアップするルールを追加

### DIFF
--- a/src/main/java/nablarch/test/support/SystemPropertyCleaner.java
+++ b/src/main/java/nablarch/test/support/SystemPropertyCleaner.java
@@ -1,0 +1,28 @@
+package nablarch.test.support;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.Properties;
+
+/**
+ * システムプロパティをテスト前の状態に戻すJUnitルール。
+ * <p>
+ * このクラスは、テスト前のシステムプロパティの状態を記録します。
+ * そして、テスト後に記録しておいた状態でシステムプロパティをロールバックします。
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class SystemPropertyCleaner extends ExternalResource {
+
+    private Properties originalProperties;
+
+    @Override
+    protected void before() {
+        originalProperties = (Properties) System.getProperties().clone();
+    }
+
+    @Override
+    protected void after() {
+        System.setProperties(originalProperties);
+    }
+}

--- a/src/test/java/nablarch/test/support/SystemPropertyCleanerTest.java
+++ b/src/test/java/nablarch/test/support/SystemPropertyCleanerTest.java
@@ -1,0 +1,66 @@
+package nablarch.test.support;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * {@link SystemPropertyCleaner} の単体テスト。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class SystemPropertyCleanerTest {
+    private final SystemPropertyCleaner sut = new SystemPropertyCleaner();
+
+    @Before
+    public void setUp() {
+        System.clearProperty("message");
+    }
+
+    @Test
+    public void 内容が変更されたプロパティの値が元に戻ること() throws Throwable {
+        System.setProperty("message", "original");
+        assertThat(System.getProperty("message"), is("original"));
+
+        sut.before();
+
+        System.setProperty("message", "modified");
+        assertThat(System.getProperty("message"), is("modified"));
+
+        sut.after();
+
+        assertThat(System.getProperty("message"), is("original"));
+    }
+
+    @Test
+    public void 削除されたプロパティが元に戻ること() throws Throwable {
+        System.setProperty("message", "original");
+        assertThat(System.getProperty("message"), is("original"));
+
+        sut.before();
+
+        System.clearProperty("message");
+        assertThat(System.getProperty("message"), is(nullValue()));
+
+        sut.after();
+
+        assertThat(System.getProperty("message"), is("original"));
+    }
+
+    @Test
+    public void 追加されたプロパティが削除されていること() throws Throwable {
+        assertThat(System.getProperty("message"), is(nullValue()));
+
+        sut.before();
+
+        System.setProperty("message", "added");
+        assertThat(System.getProperty("message"), is("added"));
+
+        sut.after();
+
+        assertThat(System.getProperty("message"), is(nullValue()));
+    }
+}


### PR DESCRIPTION
構造化ログ対応の中で、複数のプロジェクトでシステムプロパティのクリーンアップが欲しくなったので、本プロジェクトに汎用的な JUnit ルールクラスを追加しました。

処理自体は、 [nablarch-core-applog の LogTestSupport](https://github.com/nablarch/nablarch-core-applog/blob/1.2.0/src/test/java/nablarch/core/log/LogTestSupport.java) を参考にしています。