### PR TITLE
Jakarta EE 対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,30 +57,25 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.el</groupId>
       <artifactId>jakarta.el-api</artifactId>
-      <version>4.0.0</version>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>5.0.0</version>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,25 +57,21 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>eclipselink</artifactId>
-      <version>4.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>jakarta.servlet.jsp</groupId>
       <artifactId>jakarta.servlet.jsp-api</artifactId>
-      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.el</groupId>
       <artifactId>jakarta.el-api</artifactId>
-      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/nablarch/test/support/web/MockHttpSession.java
+++ b/src/main/java/nablarch/test/support/web/MockHttpSession.java
@@ -80,14 +80,6 @@ public class MockHttpSession implements jakarta.servlet.http.HttpSession {
      * {@inheritDoc}
      * @deprecated
      */
-    public jakarta.servlet.http.HttpSessionContext getSessionContext() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * {@inheritDoc}
-     * @deprecated
-     */
     public Object getValue(String arg0) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/nablarch/test/support/web/servlet/MockServletContext.java
+++ b/src/main/java/nablarch/test/support/web/servlet/MockServletContext.java
@@ -22,6 +22,16 @@ import java.util.Set;
 
 public class MockServletContext implements ServletContext {
 
+    private String contextPath;
+
+    /**
+     * コンテキストパスを設定する。
+     * @param contextPath コンテキストパス
+     */
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
+
     public Object getAttribute(String arg0) {
         throw new UnsupportedOperationException();
     }
@@ -35,7 +45,7 @@ public class MockServletContext implements ServletContext {
     }
 
     public String getContextPath() {
-        throw new UnsupportedOperationException();
+        return contextPath;
     }
 
     private Map<String, String> initParams = new HashMap<String, String>();

--- a/src/main/java/nablarch/test/support/web/servlet/MockServletRequest.java
+++ b/src/main/java/nablarch/test/support/web/servlet/MockServletRequest.java
@@ -61,7 +61,17 @@ public class MockServletRequest implements HttpServletRequest {
     public void setContextPath(String contextPath) {
         this.contextPath = contextPath;
     }
-    
+
+    private ServletContext servletContext;
+
+    /**
+     * {@link ServletContext}を設定する。
+     * @param servletContext {@link ServletContext}
+     */
+    public void setServletContext(ServletContext servletContext) {
+        this.servletContext = servletContext;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -177,7 +187,7 @@ public class MockServletRequest implements HttpServletRequest {
 
     @Override
     public ServletContext getServletContext() {
-        throw new UnsupportedOperationException();
+        return servletContext;
     }
 
     @Override

--- a/src/main/java/nablarch/test/support/web/servlet/MockServletRequest.java
+++ b/src/main/java/nablarch/test/support/web/servlet/MockServletRequest.java
@@ -4,6 +4,7 @@ import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -206,6 +207,21 @@ public class MockServletRequest implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/nablarch/test/support/web/servlet/MockServletContextTest.java
+++ b/src/test/java/nablarch/test/support/web/servlet/MockServletContextTest.java
@@ -1,0 +1,25 @@
+package nablarch.test.support.web.servlet;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * {@link MockServletContext}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class MockServletContextTest {
+
+    private final MockServletContext sut = new MockServletContext();
+
+    @Test
+    public void testContextPath() {
+        assertThat(sut.getContextPath(), is(nullValue()));
+
+        sut.setContextPath("/test");
+
+        assertThat(sut.getContextPath(), is("/test"));
+    }
+}

--- a/src/test/java/nablarch/test/support/web/servlet/MockServletRequestTest.java
+++ b/src/test/java/nablarch/test/support/web/servlet/MockServletRequestTest.java
@@ -1,0 +1,26 @@
+package nablarch.test.support.web.servlet;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * {@link MockServletRequest}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class MockServletRequestTest {
+    private final MockServletRequest sut = new MockServletRequest();
+
+    @Test
+    public void testServletContext() {
+        assertThat(sut.getServletContext(), is(nullValue()));
+
+        MockServletContext context = new MockServletContext();
+        sut.setServletContext(context);
+
+        assertThat(sut.getServletContext(), is(sameInstance(context)));
+    }
+}


### PR DESCRIPTION
[MockServletRequest と MockServletContext に機能追加している](https://github.com/nablarch/nablarch-test-support/commit/a26fde182e5653c9d1560b29331b9a000884cde4)のは、 nablarch-web-thymeleaf-adaptor のテストを通すようにするため。
Thymeleaf のバージョンがあがって、ここで追加したプロパティの値を設定できないとテストが通らなくなったため。