### PR TITLE
jmockitのmockito置き換え作業で必要になったユーティリティの追加

### DIFF
--- a/src/main/java/nablarch/test/support/reflection/ReflectionUtil.java
+++ b/src/main/java/nablarch/test/support/reflection/ReflectionUtil.java
@@ -29,33 +29,72 @@ public class ReflectionUtil {
      * @param <T> フィールドの型
      * @throws IllegalArgumentException 指定されたフィールドが見つからない場合
      */
-
-    public static <T> T getFieldValue(Object object, String fieldName) {
-        return getFieldValue(object.getClass(), object, fieldName);
-    }
-
     @SuppressWarnings("unchecked")
-    private static <T> T getFieldValue(Class<?> clazz, Object object, String fieldName) {
+    public static <T> T getFieldValue(Object object, String fieldName) {
         try {
-            final Field field = clazz.getDeclaredField(fieldName);
+            final Field field = getDeclaredField(object.getClass(), object, fieldName);
             if (!field.canAccess(object)) {
                 field.setAccessible(true);
             }
             return (T) field.get(object);
-        } catch (NoSuchFieldException e) {
-            final Class<?> superClass = clazz.getSuperclass();
-            if (superClass == null) {
-                throw new IllegalArgumentException("The field 'unknownField' is not found in object (" + object + ").");
-            } else {
-                return getFieldValue(superClass, object, fieldName);
-            }
         } catch (IllegalAccessException e) {
             // setAccessible(true) でアクセス可にするためこの例外がスローされることはない
             throw new RuntimeException(e);
         }
     }
     
-    
+    /**
+     * 指定したオブジェクトの指定したフィールドに、値を設定する。
+     * <p>
+     * このメソッドは、フィールドの可視性に関係なく値を設定できる。<br>
+     * カプセル化を破壊し、クラス間の静的な依存関係が分からなくなるため、
+     * このメソッドの乱用は避けること<br>
+     * 極力このメソッドを使用しなくてもテストができるようにクラスを設計し、
+     * どうしても可視性を無視して値を設定しなけばテストできない場合にのみ使用すること。
+     * </p>
+     * <p>
+     * 指定されたオブジェクトに指定されたフィールドが存在しない場合は、
+     * 親クラスを遡ってフィールドを探索する。
+     * </p>
+     * 
+     * @param object 値を設定するオブジェクト
+     * @param fieldName フィールドの名前
+     * @param value フィールドに設定する値
+     * @throws IllegalArgumentException 指定されたフィールドが存在しない場合
+     */
+    public static void setFieldValue(Object object, String fieldName, Object value) {
+        try {
+            final Field field = getDeclaredField(object.getClass(), object, fieldName);
+            if (!field.canAccess(object)) {
+                field.setAccessible(true);
+            }
+            field.set(object, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 指定されたフィールドを親クラスに遡って再帰的に探索して取得する。
+     * @param clazz 探索対象のクラス
+     * @param object 探索対象のオブジェクト
+     * @param fieldName 探索対象のフィールド名
+     * @return 取得した {@link Field} オブジェクト
+     * @throws IllegalArgumentException フィールドが見つからない場合
+     */
+    private static Field getDeclaredField(Class<?> clazz, Object object, String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            final Class<?> superClass = clazz.getSuperclass();
+            if (superClass == null) {
+                throw new IllegalArgumentException("The field 'unknownField' is not found in object (" + object + ").");
+            } else {
+                return getDeclaredField(superClass, object, fieldName);
+            }
+        }
+    }
+
     // インスタンス化させないためコンストラクタをprivateで宣言
     private ReflectionUtil() {}
 }

--- a/src/main/java/nablarch/test/support/reflection/ReflectionUtil.java
+++ b/src/main/java/nablarch/test/support/reflection/ReflectionUtil.java
@@ -1,0 +1,61 @@
+package nablarch.test.support.reflection;
+
+import java.lang.reflect.Field;
+
+/**
+ * リフレクションを使った処理を提供するユーティリティクラス。
+ * 
+ * @author Tanaka Tomoyuki
+ */
+public class ReflectionUtil {
+
+    /**
+     * 指定したオブジェクトの指定したフィールドの値を取得する。
+     * <p>
+     * このメソッドは、フィールドの可視性に関係なく値を取得できる。<br>
+     * カプセル化を破壊し、クラス間の静的な依存関係が分からなくなるため、
+     * このメソッドの乱用は避けること<br>
+     * 極力このメソッドを使用しなくてもテストができるようにクラスを設計し、
+     * どうしても可視性を無視して値を取得しなけばテストできない場合にのみ使用すること。
+     * </p>
+     * <p>
+     * 指定されたオブジェクトに指定されたフィールドが存在しない場合は、
+     * 親クラスを遡ってフィールドを探索する。
+     * </p>
+     * 
+     * @param object フィールドの値を取得するオブジェクト
+     * @param fieldName 取得するフィールド名
+     * @return フィールドの値
+     * @param <T> フィールドの型
+     * @throws IllegalArgumentException 指定されたフィールドが見つからない場合
+     */
+
+    public static <T> T getFieldValue(Object object, String fieldName) {
+        return getFieldValue(object.getClass(), object, fieldName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getFieldValue(Class<?> clazz, Object object, String fieldName) {
+        try {
+            final Field field = clazz.getDeclaredField(fieldName);
+            if (!field.canAccess(object)) {
+                field.setAccessible(true);
+            }
+            return (T) field.get(object);
+        } catch (NoSuchFieldException e) {
+            final Class<?> superClass = clazz.getSuperclass();
+            if (superClass == null) {
+                throw new IllegalArgumentException("The field 'unknownField' is not found in object (" + object + ").");
+            } else {
+                return getFieldValue(superClass, object, fieldName);
+            }
+        } catch (IllegalAccessException e) {
+            // setAccessible(true) でアクセス可にするためこの例外がスローされることはない
+            throw new RuntimeException(e);
+        }
+    }
+    
+    
+    // インスタンス化させないためコンストラクタをprivateで宣言
+    private ReflectionUtil() {}
+}

--- a/src/test/java/nablarch/test/support/reflection/AbstractClass.java
+++ b/src/test/java/nablarch/test/support/reflection/AbstractClass.java
@@ -1,0 +1,4 @@
+package nablarch.test.support.reflection;
+
+public abstract class AbstractClass {
+}

--- a/src/test/java/nablarch/test/support/reflection/NoDefaultArgConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/NoDefaultArgConstructor.java
@@ -1,0 +1,5 @@
+package nablarch.test.support.reflection;
+
+public class NoDefaultArgConstructor {
+    public NoDefaultArgConstructor(String text) {}
+}

--- a/src/test/java/nablarch/test/support/reflection/PackagePrivateConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/PackagePrivateConstructor.java
@@ -1,0 +1,8 @@
+package nablarch.test.support.reflection;
+
+public class PackagePrivateConstructor {
+    public final String text;
+    PackagePrivateConstructor() {
+        text = "PackagePrivateConstructor";
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/Parent.java
+++ b/src/test/java/nablarch/test/support/reflection/Parent.java
@@ -1,0 +1,9 @@
+package nablarch.test.support.reflection;
+
+public class Parent {
+    public String publicField = "Parent#publicField";
+    protected String protectedField = "Parent#protectedField";
+    String packagePrivateField = "Parent#packagePrivateField";
+    private String privateField = "Parent#privateField";
+    private String parentOnlyField = "Parent#parentOnlyField";
+}

--- a/src/test/java/nablarch/test/support/reflection/Parent.java
+++ b/src/test/java/nablarch/test/support/reflection/Parent.java
@@ -6,4 +6,20 @@ public class Parent {
     String packagePrivateField = "Parent#packagePrivateField";
     private String privateField = "Parent#privateField";
     private String parentOnlyField = "Parent#parentOnlyField";
+    
+    public String publicMethod () { return "Parent#publicMethod"; }
+    protected String protectedMethod () { return "Parent#protectedMethod"; }
+    String packagePrivateMethod () { return "Parent#packagePrivateMethod"; }
+    private String privateMethod () { return "Parent#privateMethod"; }
+    private String parentOnlyMethod () { return "Parent#parentOnlyMethod"; }
+
+    private void voidMethod () {}
+    
+    private String argsMethod(int i, String s) { return "(" + i + ", " + s + ")"; }
+    
+    private String overload() { return "no args"; }
+    private String overload(int i) { return "i=" + i; }
+    private String overload(String s) { return "s=" + s; }
+    
+    private void throwException() { throw new UnsupportedOperationException("test"); }
 }

--- a/src/test/java/nablarch/test/support/reflection/Parent.java
+++ b/src/test/java/nablarch/test/support/reflection/Parent.java
@@ -7,6 +7,14 @@ public class Parent {
     private static String PRIVATE_FIELD = "Parent#PRIVATE_FIELD";
     private static String PARENT_ONLY_FIELD = "Parent#PARENT_ONLY_FIELD";
     
+    public static void init() {
+        PUBLIC_FIELD = "Parent#PUBLIC_FIELD";
+        PROTECTED_FIELD = "Parent#PROTECTED_FIELD";
+        PACKAGE_PRIVATE_FIELD = "Parent#PACKAGE_PRIVATE_FIELD";
+        PRIVATE_FIELD = "Parent#PRIVATE_FIELD";
+        PARENT_ONLY_FIELD = "Parent#PARENT_ONLY_FIELD";
+    }
+    
     public String publicField = "Parent#publicField";
     protected String protectedField = "Parent#protectedField";
     String packagePrivateField = "Parent#packagePrivateField";

--- a/src/test/java/nablarch/test/support/reflection/Parent.java
+++ b/src/test/java/nablarch/test/support/reflection/Parent.java
@@ -1,6 +1,12 @@
 package nablarch.test.support.reflection;
 
 public class Parent {
+    public static String PUBLIC_FIELD = "Parent#PUBLIC_FIELD";
+    protected static String PROTECTED_FIELD = "Parent#PROTECTED_FIELD";
+    static String PACKAGE_PRIVATE_FIELD = "Parent#PACKAGE_PRIVATE_FIELD";
+    private static String PRIVATE_FIELD = "Parent#PRIVATE_FIELD";
+    private static String PARENT_ONLY_FIELD = "Parent#PARENT_ONLY_FIELD";
+    
     public String publicField = "Parent#publicField";
     protected String protectedField = "Parent#protectedField";
     String packagePrivateField = "Parent#packagePrivateField";

--- a/src/test/java/nablarch/test/support/reflection/PrivateConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/PrivateConstructor.java
@@ -1,0 +1,8 @@
+package nablarch.test.support.reflection;
+
+public class PrivateConstructor {
+    public final String text;
+    private PrivateConstructor() {
+        text = "PrivateConstructor";
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/ProtectedConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/ProtectedConstructor.java
@@ -1,0 +1,8 @@
+package nablarch.test.support.reflection;
+
+public class ProtectedConstructor {
+    public final String text;
+    protected ProtectedConstructor() {
+        text = "ProtectedConstructor";
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/PublicConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/PublicConstructor.java
@@ -1,0 +1,8 @@
+package nablarch.test.support.reflection;
+
+public class PublicConstructor {
+    public final String text;
+    public PublicConstructor() {
+        text = "PublicConstructor";
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
+++ b/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
@@ -46,7 +46,7 @@ public class ReflectionUtilTest {
     }
 
     /**
-     * 指定されたフィールドが存在しない場合は例外がスローされること。
+     * getFieldValueで指定されたフィールドが存在しない場合は例外がスローされること。
      */
     @Test
     public void testGetFieldValueThrowsExceptionIfNotFoundField() {
@@ -54,6 +54,62 @@ public class ReflectionUtilTest {
 
         final IllegalArgumentException exception
                 = assertThrows(IllegalArgumentException.class, () -> ReflectionUtil.getFieldValue(parent, "unknownField"));
+
+        assertThat(exception.getMessage(), is("The field 'unknownField' is not found in object (" + parent + ")."));
+    }
+
+    /**
+     * 指定されたオブジェクトのフィールドに可視性に関係なく値が設定できること。
+     */
+    @Test
+    public void testSetFieldValue() {
+        final Parent parent = new Parent();
+        
+        ReflectionUtil.setFieldValue(parent, "publicField", "PUBLIC_FIELD");
+        ReflectionUtil.setFieldValue(parent, "protectedField", "PROTECTED_FIELD");
+        ReflectionUtil.setFieldValue(parent, "packagePrivateField", "PACKAGE_PRIVATE_FIELD");
+        ReflectionUtil.setFieldValue(parent, "privateField", "PRIVATE_FIELD");
+
+        assertThat(ReflectionUtil.getFieldValue(parent, "publicField"), is("PUBLIC_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "protectedField"), is("PROTECTED_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "packagePrivateField"), is("PACKAGE_PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "privateField"), is("PRIVATE_FIELD"));
+    }
+
+    /**
+     * サブクラスのフィールドに対してsetFieldValueを使ったときのテスト。
+     * <ul>
+     *   <li>オーバーライドされたフィールドに設定できること</li>
+     *   <li>親クラスのフィールドも設定できること</li>
+     * </ul>
+     */
+    @Test
+    public void testSetFieldValueAtSubClass() {
+        final Sub sub = new Sub();
+
+        ReflectionUtil.setFieldValue(sub, "publicField", "PUBLIC_FIELD");
+        ReflectionUtil.setFieldValue(sub, "protectedField", "PROTECTED_FIELD");
+        ReflectionUtil.setFieldValue(sub, "packagePrivateField", "PACKAGE_PRIVATE_FIELD");
+        ReflectionUtil.setFieldValue(sub, "privateField", "PRIVATE_FIELD");
+        ReflectionUtil.setFieldValue(sub, "parentOnlyField", "PARENT_ONLY_FIELD");
+
+        assertThat(ReflectionUtil.getFieldValue(sub, "publicField"), is("PUBLIC_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "protectedField"), is("PROTECTED_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "packagePrivateField"), is("PACKAGE_PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "privateField"), is("PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "parentOnlyField"), is("PARENT_ONLY_FIELD"));
+    }
+
+    /**
+     * setFieldValueで指定されたフィールドが存在しない場合は例外がスローされること。
+     */
+    @Test
+    public void testSetFieldValueThrowsExceptionIfNotFoundField() {
+        final Parent parent = new Parent();
+
+        final IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class,
+                () -> ReflectionUtil.setFieldValue(parent, "unknownField", "value"));
 
         assertThat(exception.getMessage(), is("The field 'unknownField' is not found in object (" + parent + ")."));
     }

--- a/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
+++ b/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
@@ -1,0 +1,60 @@
+package nablarch.test.support.reflection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * {@link ReflectionUtil}の単体テスト。
+ * 
+ * @author Tanaka Tomoyuki
+ */
+public class ReflectionUtilTest {
+
+    /**
+     * 指定されたオブジェクトで定義されたフィールドは可視性に関係なく全て取得できること。
+     */
+    @Test
+    public void testGetFieldValue() {
+        final Parent parent = new Parent();
+        
+        assertThat(ReflectionUtil.getFieldValue(parent, "publicField"), is("Parent#publicField"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "protectedField"), is("Parent#protectedField"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "packagePrivateField"), is("Parent#packagePrivateField"));
+        assertThat(ReflectionUtil.getFieldValue(parent, "privateField"), is("Parent#privateField"));
+    }
+
+    /**
+     * サブクラスのフィールドに対してgetFieldValueを使ったときのテスト。
+     * <ul>
+     *   <li>オーバーライドされたフィールドはサブクラスの値が取得できること</li>
+     *   <li>親クラスのフィールドも取得できること</li>
+     * </ul>
+     */
+    @Test
+    public void testGetFieldValueAtSubClass() {
+        final Sub sub = new Sub();
+
+        assertThat(ReflectionUtil.getFieldValue(sub, "publicField"), is("Sub#publicField"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "protectedField"), is("Sub#protectedField"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "packagePrivateField"), is("Sub#packagePrivateField"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "privateField"), is("Sub#privateField"));
+        assertThat(ReflectionUtil.getFieldValue(sub, "parentOnlyField"), is("Parent#parentOnlyField"));
+    }
+
+    /**
+     * 指定されたフィールドが存在しない場合は例外がスローされること。
+     */
+    @Test
+    public void testGetFieldValueThrowsExceptionIfNotFoundField() {
+        final Parent parent = new Parent();
+
+        final IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> ReflectionUtil.getFieldValue(parent, "unknownField"));
+
+        assertThat(exception.getMessage(), is("The field 'unknownField' is not found in object (" + parent + ")."));
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
+++ b/src/test/java/nablarch/test/support/reflection/ReflectionUtilTest.java
@@ -1,6 +1,5 @@
 package nablarch.test.support.reflection;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -17,6 +16,33 @@ import static org.junit.Assert.assertThrows;
  * @author Tanaka Tomoyuki
  */
 public class ReflectionUtilTest {
+
+    /**
+     * 指定されたクラスで定義されたフィールドは可視性に関係なく全て取得できること。
+     */
+    @Test
+    public void testGetFieldValueForClassField() {
+        assertThat(ReflectionUtil.getFieldValue(Parent.class, "PUBLIC_FIELD"), is("Parent#PUBLIC_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Parent.class, "PROTECTED_FIELD"), is("Parent#PROTECTED_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Parent.class, "PACKAGE_PRIVATE_FIELD"), is("Parent#PACKAGE_PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Parent.class, "PRIVATE_FIELD"), is("Parent#PRIVATE_FIELD"));
+    }
+
+    /**
+     * サブクラスのstaticフィールドに対してgetFieldValueを使ったときのテスト。
+     * <ul>
+     *   <li>オーバーライドされたフィールドはサブクラスの値が取得できること</li>
+     *   <li>親クラスのフィールドも取得できること</li>
+     * </ul>
+     */
+    @Test
+    public void testGetFieldValueForClassFieldAtSubClass() {
+        assertThat(ReflectionUtil.getFieldValue(Sub.class, "PUBLIC_FIELD"), is("Sub#PUBLIC_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Sub.class, "PROTECTED_FIELD"), is("Sub#PROTECTED_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Sub.class, "PACKAGE_PRIVATE_FIELD"), is("Sub#PACKAGE_PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Sub.class, "PRIVATE_FIELD"), is("Sub#PRIVATE_FIELD"));
+        assertThat(ReflectionUtil.getFieldValue(Sub.class, "PARENT_ONLY_FIELD"), is("Parent#PARENT_ONLY_FIELD"));
+    }
 
     /**
      * 指定されたオブジェクトで定義されたフィールドは可視性に関係なく全て取得できること。

--- a/src/test/java/nablarch/test/support/reflection/Sub.java
+++ b/src/test/java/nablarch/test/support/reflection/Sub.java
@@ -5,4 +5,9 @@ public class Sub extends Parent {
     protected String protectedField = "Sub#protectedField";
     String packagePrivateField = "Sub#packagePrivateField";
     private String privateField = "Sub#privateField";
+
+    public String publicMethod () { return "Sub#publicMethod"; }
+    protected String protectedMethod () { return "Sub#protectedMethod"; }
+    String packagePrivateMethod () { return "Sub#packagePrivateMethod"; }
+    private String privateMethod () { return "Sub#privateMethod"; }
 }

--- a/src/test/java/nablarch/test/support/reflection/Sub.java
+++ b/src/test/java/nablarch/test/support/reflection/Sub.java
@@ -1,6 +1,11 @@
 package nablarch.test.support.reflection;
 
 public class Sub extends Parent {
+    public static String PUBLIC_FIELD = "Sub#PUBLIC_FIELD";
+    protected static String PROTECTED_FIELD = "Sub#PROTECTED_FIELD";
+    static String PACKAGE_PRIVATE_FIELD = "Sub#PACKAGE_PRIVATE_FIELD";
+    private static String PRIVATE_FIELD = "Sub#PRIVATE_FIELD";
+    
     public String publicField = "Sub#publicField";
     protected String protectedField = "Sub#protectedField";
     String packagePrivateField = "Sub#packagePrivateField";

--- a/src/test/java/nablarch/test/support/reflection/Sub.java
+++ b/src/test/java/nablarch/test/support/reflection/Sub.java
@@ -1,0 +1,8 @@
+package nablarch.test.support.reflection;
+
+public class Sub extends Parent {
+    public String publicField = "Sub#publicField";
+    protected String protectedField = "Sub#protectedField";
+    String packagePrivateField = "Sub#packagePrivateField";
+    private String privateField = "Sub#privateField";
+}

--- a/src/test/java/nablarch/test/support/reflection/Sub.java
+++ b/src/test/java/nablarch/test/support/reflection/Sub.java
@@ -6,6 +6,14 @@ public class Sub extends Parent {
     static String PACKAGE_PRIVATE_FIELD = "Sub#PACKAGE_PRIVATE_FIELD";
     private static String PRIVATE_FIELD = "Sub#PRIVATE_FIELD";
     
+    public static void init() {
+        Parent.init();
+        PUBLIC_FIELD = "Sub#PUBLIC_FIELD";
+        PROTECTED_FIELD = "Sub#PROTECTED_FIELD";
+        PACKAGE_PRIVATE_FIELD = "Sub#PACKAGE_PRIVATE_FIELD";
+        PRIVATE_FIELD = "Sub#PRIVATE_FIELD";
+    }
+    
     public String publicField = "Sub#publicField";
     protected String protectedField = "Sub#protectedField";
     String packagePrivateField = "Sub#packagePrivateField";

--- a/src/test/java/nablarch/test/support/reflection/ThrowExceptionConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/ThrowExceptionConstructor.java
@@ -1,0 +1,9 @@
+package nablarch.test.support.reflection;
+
+import java.io.IOException;
+
+public class ThrowExceptionConstructor {
+    public ThrowExceptionConstructor() throws IOException {
+        throw new IOException("test");
+    }
+}

--- a/src/test/java/nablarch/test/support/reflection/ThrowRuntimeExceptionConstructor.java
+++ b/src/test/java/nablarch/test/support/reflection/ThrowRuntimeExceptionConstructor.java
@@ -1,0 +1,7 @@
+package nablarch.test.support.reflection;
+
+public class ThrowRuntimeExceptionConstructor {
+    public ThrowRuntimeExceptionConstructor() {
+        throw new UnsupportedOperationException("test");
+    }
+}


### PR DESCRIPTION
- jmockit に組み込まれていた `Deencapsulation` の代替として、 `ReflectionUtil` を追加
  - リフレクションを使ってカプセル化を破壊してフィールドやメソッドにアクセスするもので基本的に利用すべきではないので、テストで実際に使われていて必要となったものだけを作成している